### PR TITLE
[Feature/#87] 임시 저장된 글들 조회시 빈값으로 나오도록 수정

### DIFF
--- a/src/main/java/shop/zip/travel/domain/post/data/DefaultValue.java
+++ b/src/main/java/shop/zip/travel/domain/post/data/DefaultValue.java
@@ -1,9 +1,15 @@
 package shop.zip.travel.domain.post.data;
 
+import java.time.LocalDate;
+
 public enum DefaultValue {
-  LOCAL_DATE("1000-01-01"),
+  LOCAL_DATE("1899-02-01"),
   STRING("1234567890qwertyuiop"),
   LONG("0");
+
+  private static final String STRING_RETURN_VALUE = "";
+  private static final String DEFAULT_IMAGE_URL =
+      "https://unsplash.com/ko/%EC%82%AC%EC%A7%84/BWCgQw25XUE?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText";
 
   private final String value;
 
@@ -18,5 +24,31 @@ public enum DefaultValue {
 
   public boolean isEqual(String request) {
     return value.equals(request);
+  }
+
+  public static LocalDate orGetLocalDateReturnValue(LocalDate requestLocalDate) {
+    if (LOCAL_DATE.isEqual(requestLocalDate.toString())) {
+      return null;
+    }
+    return requestLocalDate;
+  }
+
+  public static String orGetStringReturnValue(String requestString) {
+    if (STRING.isEqual(requestString)) {
+      return STRING_RETURN_VALUE;
+    }
+    return requestString;
+  }
+
+  public static String orGetDefaultImage(String request) {
+    if (STRING.isEqual(request)) {
+      return DEFAULT_IMAGE_URL;
+    }
+    return request;
+  }
+
+  public static boolean isBefore(LocalDate request) {
+    return request.isBefore(LocalDate.parse(LOCAL_DATE.getValue())) ||
+        request.equals(LocalDate.parse(LOCAL_DATE.getValue()));
   }
 }

--- a/src/main/java/shop/zip/travel/domain/post/data/DefaultValue.java
+++ b/src/main/java/shop/zip/travel/domain/post/data/DefaultValue.java
@@ -26,12 +26,6 @@ public enum DefaultValue {
     return value.equals(request);
   }
 
-  public static LocalDate orGetLocalDateReturnValue(LocalDate requestLocalDate) {
-    if (LOCAL_DATE.isEqual(requestLocalDate.toString())) {
-      return null;
-    }
-    return requestLocalDate;
-  }
 
   public static String orGetStringReturnValue(String requestString) {
     if (STRING.isEqual(requestString)) {

--- a/src/main/java/shop/zip/travel/domain/post/image/dto/TravelPhotoCreateReq.java
+++ b/src/main/java/shop/zip/travel/domain/post/image/dto/TravelPhotoCreateReq.java
@@ -1,5 +1,7 @@
 package shop.zip.travel.domain.post.image.dto;
 
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetStringReturnValue;
+
 import shop.zip.travel.domain.post.data.DefaultValue;
 import shop.zip.travel.domain.post.image.entity.TravelPhoto;
 
@@ -15,7 +17,7 @@ public record TravelPhotoCreateReq(
 
     public static TravelPhotoCreateReq toDto(TravelPhoto travelPhoto) {
         return new TravelPhotoCreateReq(
-            travelPhoto.getUrl()
+            orGetStringReturnValue(travelPhoto.getUrl())
         );
     }
 }

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/SubTravelogueUpdate.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/SubTravelogueUpdate.java
@@ -9,7 +9,6 @@ import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 public record SubTravelogueUpdate(
     String title,
     String content,
-    int day,
     List<Address> addresses,
     Set<Transportation> transportationSet,
     List<TravelPhoto> travelPhotoCreateReqs

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/req/SubTravelogueUpdateReq.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/req/SubTravelogueUpdateReq.java
@@ -16,7 +16,6 @@ import shop.zip.travel.domain.post.subTravelogue.dto.SubTravelogueUpdate;
 public record SubTravelogueUpdateReq(
     String title,
     String content,
-    int day,
     List<TempAddress> addresses,
     Set<Transportation> transportationSet,
     List<TravelPhotoCreateReq> travelPhotoCreateReqs
@@ -26,7 +25,6 @@ public record SubTravelogueUpdateReq(
         return new SubTravelogueUpdate(
             title.isBlank() ? DefaultValue.STRING.getValue() : title,
             content.isBlank() ? DefaultValue.STRING.getValue() : content,
-            day,
             toAddresses(),
             transportationSet,
             toTravelPhotos()

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/AddressRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/AddressRes.java
@@ -1,0 +1,16 @@
+package shop.zip.travel.domain.post.subTravelogue.dto.res;
+
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetStringReturnValue;
+
+import shop.zip.travel.domain.post.subTravelogue.data.Address;
+
+public record AddressRes(
+    String region
+) {
+
+  public static AddressRes toDto(Address address) {
+    return new AddressRes(
+        orGetStringReturnValue(address.getRegion())
+    );
+  }
+}

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
@@ -1,9 +1,10 @@
 package shop.zip.travel.domain.post.subTravelogue.dto.res;
 
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetStringReturnValue;
+
 import java.util.List;
 import java.util.Set;
 import shop.zip.travel.domain.post.image.dto.TravelPhotoCreateReq;
-import shop.zip.travel.domain.post.subTravelogue.data.Address;
 import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 
@@ -11,17 +12,20 @@ public record SubTravelogueDetailRes(
     String title,
     String content,
     int day,
-    List<Address> addresses,
+    List<AddressRes> addresses,
     Set<Transportation> transportationSet,
     List<TravelPhotoCreateReq> travelPhotoCreateReqs
 ) {
 
     public static SubTravelogueDetailRes toDto(SubTravelogue subTravelogue) {
         return new SubTravelogueDetailRes(
-            subTravelogue.getTitle(),
-            subTravelogue.getContent(),
+            orGetStringReturnValue(subTravelogue.getTitle()),
+            orGetStringReturnValue(subTravelogue.getContent()),
             subTravelogue.getDay(),
-            subTravelogue.getAddresses(),
+            subTravelogue.getAddresses()
+                .stream()
+                .map(AddressRes::toDto)
+                .toList(),
             subTravelogue.getTransportationSet(),
             subTravelogue.getPhotos()
                 .stream()

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueService.java
@@ -27,6 +27,7 @@ public class SubTravelogueService {
     public SubTravelogueCreateRes save(SubTravelogueCreateReq createReq, Long travelogueId) {
 
         Travelogue travelogue = travelogueService.getTravelogue(travelogueId);
+        verifyDay(createReq.day(), travelogue.getPeriod().getNights() + 1);
         SubTravelogue subTravelogue = subTravelogueRepository.save(createReq.toSubTravelogue());
 
         addPhotosTo(subTravelogue, createReq);
@@ -49,5 +50,11 @@ public class SubTravelogueService {
                 .stream()
                 .map(TravelPhotoCreateReq::toEntity)
                 .toList());
+    }
+
+    private void verifyDay(int day, Long period) {
+        if (day > period) {
+            throw new IllegalArgumentException("day는 여행한 기간보다 클 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/data/Period.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/data/Period.java
@@ -61,7 +61,7 @@ public class Period {
 
 
     public boolean cannotPublish() {
-        return DefaultValue.LOCAL_DATE.isEqual(startDate.toString()) ||
-            DefaultValue.LOCAL_DATE.isEqual(endDate.toString());
+        return DefaultValue.isBefore(startDate) ||
+            DefaultValue.isBefore(endDate);
     }
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
@@ -1,5 +1,8 @@
 package shop.zip.travel.domain.post.travelogue.dto.res;
 
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetDefaultImage;
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetStringReturnValue;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -33,12 +36,12 @@ public record TravelogueDetailRes(
         travelogue.getMember().getProfileImageUrl(),
         travelogue.getMember().getNickname(),
         travelogue.getId(),
-        travelogue.getTitle(),
-        travelogue.getCountry().getName(),
+        orGetStringReturnValue(travelogue.getTitle()),
+        orGetStringReturnValue(travelogue.getCountry().getName()),
         travelogue.getPeriod().getNights(),
         travelogue.getPeriod().getNights() + 1,
         travelogue.getCost().getTotal(),
-        travelogue.getThumbnail(),
+        orGetDefaultImage(travelogue.getThumbnail()),
         travelogue.getSubTravelogues()
             .stream()
             .map(SubTravelogueDetailRes::toDto)

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueSimpleRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueSimpleRes.java
@@ -1,5 +1,7 @@
 package shop.zip.travel.domain.post.travelogue.dto.res;
 
+import static shop.zip.travel.domain.post.data.DefaultValue.orGetStringReturnValue;
+
 import shop.zip.travel.domain.member.dto.MemberSimpleRes;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
 
@@ -23,12 +25,12 @@ public record TravelogueSimpleRes(
 
 		return new TravelogueSimpleRes(
 				travelogueSimple.travelogueId(),
-				travelogueSimple.title(),
+				orGetStringReturnValue(travelogueSimple.title()),
 				nights,
 				nights + 1,
 				travelogueSimple.totalCost(),
-				travelogueSimple.country(),
-				travelogueSimple.thumbnail(),
+				orGetStringReturnValue(travelogueSimple.country()),
+				orGetStringReturnValue(travelogueSimple.thumbnail()),
 				MemberSimpleRes.toDto(travelogueSimple),
 				likeCount
 		);

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
@@ -126,7 +126,7 @@ public class Travelogue extends BaseTimeEntity {
 	}
 
 	public List<SubTravelogue> getSubTravelogues() {
-		return new ArrayList<>(subTravelogues);
+		return sortSubTravelogues(new ArrayList<>(subTravelogues));
 	}
 
 	public Member getMember() {
@@ -173,7 +173,7 @@ public class Travelogue extends BaseTimeEntity {
 	}
 
 	private void verifySubTraveloguesSize() {
-		if (this.subTravelogues.size() > this.period.getNights() + 1) {
+		if (this.subTravelogues.size() >= this.period.getNights() + 1) {
 			throw new IllegalArgumentException("이미 모든 서브 트레블로그가 작성되어 있습니다.");
 		}
 	}
@@ -239,7 +239,11 @@ public class Travelogue extends BaseTimeEntity {
 
 	private void changeSubTravelogues(List<SubTravelogue> newSubTravelogues) {
 		this.subTravelogues.clear();
-		newSubTravelogues.sort((sub1, sub2) -> {
+		this.subTravelogues.addAll(newSubTravelogues);
+	}
+
+	private List<SubTravelogue> sortSubTravelogues(List<SubTravelogue> requestSubTravelogues) {
+		requestSubTravelogues.sort((sub1, sub2) -> {
 			int day1 = sub1.getDay();
 			int day2 = sub2.getDay();
 
@@ -249,7 +253,8 @@ public class Travelogue extends BaseTimeEntity {
 				return -1;
 			}
 		});
-		this.subTravelogues.addAll(newSubTravelogues);
+
+		return requestSubTravelogues;
 	}
 
 }

--- a/src/test/java/shop/zip/travel/domain/member/service/MemberMyTravelogueServiceTest.java
+++ b/src/test/java/shop/zip/travel/domain/member/service/MemberMyTravelogueServiceTest.java
@@ -155,7 +155,6 @@ class MemberMyTravelogueServiceTest {
     SubTravelogueUpdateReq subTravelogueUpdateReq = new SubTravelogueUpdateReq(
         "오사카 1일차",
         "오사카 1일차 여행기입니다.",
-        1,
         List.of(DummyGenerator.createTempAddress()),
         Set.of(Transportation.SUBWAY),
         new ArrayList<>()

--- a/src/test/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueServiceTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueServiceTest.java
@@ -56,7 +56,7 @@ class SubTravelogueServiceTest {
 
     Member member = DummyGenerator.createMember();
 
-    Travelogue travelogue = new FakeTravelogue(1L, DummyGenerator.createTravelogue(member));
+    Travelogue travelogue = new FakeTravelogue(1L, DummyGenerator.createTempTravelogue(member));
 
     SubTravelogue actual = new FakeSubTravelogue(1L, subTravelogueCreateReq.toSubTravelogue());
 

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
@@ -267,7 +267,6 @@ public class DummyGenerator {
     return new SubTravelogueUpdateReq(
         "일본 오사카 1일차입니다.",
         "오사카 1일차인데 눌러앉고 싶네요.",
-        1,
         List.of(createTempAddress()),
         Set.of(Transportation.BUS),
         new ArrayList<>()

--- a/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
@@ -319,7 +319,6 @@ class MemberMyTravelogueControllerTest {
             requestFields(
                 fieldWithPath("title").type(JsonFieldType.STRING).description("소제목"),
                 fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
-                fieldWithPath("day").type(JsonFieldType.NUMBER).description("서브 게시물의 일차 정보"),
                 fieldWithPath("addresses[].region").type(JsonFieldType.STRING)
                     .description("방문한 장소명"),
                 fieldWithPath("transportationSet").type(JsonFieldType.ARRAY)

--- a/src/test/java/shop/zip/travel/presentation/subTravelogue/SubTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/subTravelogue/SubTravelogueControllerTest.java
@@ -82,9 +82,12 @@ class SubTravelogueControllerTest {
         List.of(new TravelPhotoCreateReq("www.google.com"))
     );
 
+    Travelogue tempTravelogue = travelogueRepository.save(
+        DummyGenerator.createTempTravelogue(member));
+
     String token = "Bearer " + jwtTokenProvider.createAccessToken(member.getId());
 
-    mockMvc.perform(post("/api/travelogues/{travelogueId}/subTravelogues", travelogue.getId())
+    mockMvc.perform(post("/api/travelogues/{travelogueId}/subTravelogues", tempTravelogue.getId())
             .header("AccessToken", token)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(subTravelogueCreateReq)))
@@ -99,7 +102,7 @@ class SubTravelogueControllerTest {
             requestFields(
                 fieldWithPath("title").description("서브 게시물 제목"),
                 fieldWithPath("content").description("서브 게시물 내용"),
-                fieldWithPath("day").description("서브 게시물 일차"),
+                fieldWithPath("day").description("서브 게시물 일차 정보"),
                 fieldWithPath("addresses[]").description("방문한 장소 리스트"),
                 fieldWithPath("addresses[].region").description("방문한 장소"),
                 fieldWithPath("transportationSet[]").description("이용한 이동수단 리스트"),


### PR DESCRIPTION
### Response
#### 임시 저장한 값을 조회했을 때 데이터 상태
```
"content": [
        {
            "travelogueId": 1,
            "title": "",
            "nights": 0,
            "days": 1,
            "totalCost": 0,
            "country": "",
            "thumbnail": "",
            "member": {
                "nickname": "프로여행러",
                "profileImageUrl": "default"
            },
            "likeCount": 0
        }
    ],
```

## 개발 내용 한줄 요약
> 개발한 내용을 한줄로 요약해주세요.

임시 저장으로 default 값으로 저장된 값들을 빈값 혹은 null 로 전환해서 전달하도록 수정하였습니다.

## 개발 세부 사항
> 어떤 것을 개발했는지 자세히 작성해주세요.

- day 필드에 대해 validation을 추가하였습니다.
- subTravelogue 리스트를 전달할때 day를 기준으로 순서가 보장되도록 수정하였습니다.
- 임시 저장된 글들을 조회하는 API 에서 default 값을 가진 경우 빈값으로 전달되도록 수정하였습니다.
- h2에 default로 지정한 날짜보다 하루 이전으로 저장되는 이슈가 발생하여 default 로 지정된 날짜보다 이전일 경우에 publish가 안되고, nights가 -1로 전달되도록 수정하였습니다.

## 집중적인 코드리뷰
> 좀 더 상세하게 리뷰 받고 싶은 부분을 기재해주세요.


## 관련 이슈
> 관련 이슈를 작성해주세요
- #1, #3

<!--
## 리마인더 (주석처리)
[]본인의 로컬에서 정상 동작하는지 확인해주세요.
[]최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
[]API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
[]Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
[]commit 메시지 제대로 작성해주세요.
-->

## 코드리뷰 룰
R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
C(Comment): 웬만하면 고려해주시면 좋겠습니다.
A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
