### PR TITLE
[#99] DateTime 리턴 포맷 변경

### DIFF
--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/PeriodDetailForUpdateRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/PeriodDetailForUpdateRes.java
@@ -1,0 +1,22 @@
+package shop.zip.travel.domain.post.travelogue.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDate;
+import shop.zip.travel.domain.post.travelogue.data.Period;
+
+public record PeriodDetailForUpdateRes(
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    LocalDate startDate,
+
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    LocalDate endDate
+) {
+
+  public static PeriodDetailForUpdateRes toDto(Period period) {
+    return new PeriodDetailForUpdateRes(
+        period.getStartDate(),
+        period.getEndDate()
+    );
+  }
+}

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailForUpdateRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailForUpdateRes.java
@@ -4,12 +4,11 @@ import java.util.List;
 import shop.zip.travel.domain.post.data.Country;
 import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 import shop.zip.travel.domain.post.travelogue.data.Cost;
-import shop.zip.travel.domain.post.travelogue.data.Period;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 
 public record TravelogueDetailForUpdateRes(
     String title,
-    Period period,
+    PeriodDetailForUpdateRes period,
     Country country,
     Cost cost,
     String thumbnail,
@@ -19,7 +18,7 @@ public record TravelogueDetailForUpdateRes(
   public static TravelogueDetailForUpdateRes toDto(Travelogue travelogue) {
     return new TravelogueDetailForUpdateRes(
         travelogue.getTitle(),
-        travelogue.getPeriod(),
+        PeriodDetailForUpdateRes.toDto(travelogue.getPeriod()),
         travelogue.getCountry(),
         travelogue.getCost(),
         travelogue.getThumbnail(),


### PR DESCRIPTION
### Response
![스크린샷 2023-03-12 21 07 50](https://user-images.githubusercontent.com/75114420/224543698-4f4827f4-da25-4959-8993-3b530af909f0.png)

## 개발 내용 한줄 요약
> 개발한 내용을 한줄로 요약해주세요.

- LocalDate가 리턴될때 array로 2022, 2, 3 으로 전달되던 것을 "2022-02-03" 으로 전달되도록 변경하였습니다.
- 해당 포맷을 갖출 수 있게 하기 위해 Period를 감싸는 DTO를 하나 더 추가하였습니다.

## 관련 이슈
> 관련 이슈를 작성해주세요
- #99 

<!--
## 리마인더 (주석처리)
[]본인의 로컬에서 정상 동작하는지 확인해주세요.
[]최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
[]API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
[]Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
[]commit 메시지 제대로 작성해주세요.
-->

## 코드리뷰 룰
R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
C(Comment): 웬만하면 고려해주시면 좋겠습니다.
A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
