### PR TITLE
[Feature/#102] 게시글 상세조회에 작성자 판단 여부 필드 추가

### DIFF
--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
@@ -8,6 +8,7 @@ import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 
 public record SubTravelogueDetailRes(
+    Long subTravelogueId,
     String title,
     String content,
     int day,
@@ -18,6 +19,7 @@ public record SubTravelogueDetailRes(
 
     public static SubTravelogueDetailRes toDto(SubTravelogue subTravelogue) {
         return new SubTravelogueDetailRes(
+            subTravelogue.getId(),
             subTravelogue.getTitle(),
             subTravelogue.getContent(),
             subTravelogue.getDay(),

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
@@ -24,11 +24,17 @@ public record TravelogueDetailRes(
     Long countLikes,
     boolean isLiked,
     Long viewCount,
-    Boolean bookmarked
+    Boolean bookmarked,
+    boolean isWriter
 ) {
 
-  public static TravelogueDetailRes toDto(Travelogue travelogue, Long countLikes, Boolean isLiked,  Boolean isBookmarked) {
-
+  public static TravelogueDetailRes toDto(
+      Travelogue travelogue,
+      Long countLikes,
+      Boolean isLiked,
+      Boolean isBookmarked,
+      boolean isWriter
+  ) {
     return new TravelogueDetailRes(
         travelogue.getMember().getProfileImageUrl(),
         travelogue.getMember().getNickname(),
@@ -51,7 +57,8 @@ public record TravelogueDetailRes(
         countLikes,
         isLiked,
         travelogue.getViewCount(),
-        isBookmarked
+        isBookmarked,
+        isWriter
     );
 
   }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
@@ -1,7 +1,6 @@
 package shop.zip.travel.domain.post.travelogue.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -26,8 +25,6 @@ import shop.zip.travel.global.error.ErrorCode;
 @Service
 @Transactional(readOnly = true)
 public class TravelogueService {
-
-  private final Logger log = LoggerFactory.getLogger(TravelogueService.class);
 
   private static final boolean PUBLISH = true;
 
@@ -85,8 +82,9 @@ public class TravelogueService {
     Suggestion suggestion = new Suggestion(travelogue, memberId);
     suggestionRepository.save(suggestion);
 
+    boolean isWriter = Objects.equals(travelogue.getMember().getId(), memberId);
 
-    return TravelogueDetailRes.toDto(travelogue, countLikes, isLiked, isBookmarked);
+    return TravelogueDetailRes.toDto(travelogue, countLikes, isLiked, isBookmarked, isWriter);
   }
 
   private void setViewCount(Long travelogueId, boolean canAddViewCount) {

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
@@ -82,7 +82,7 @@ public class TravelogueService {
     Suggestion suggestion = new Suggestion(travelogue, memberId);
     suggestionRepository.save(suggestion);
 
-    boolean isWriter = Objects.equals(travelogue.getMember().getId(), memberId);
+    boolean isWriter = isWriter(travelogue.getMember(), memberId);
 
     return TravelogueDetailRes.toDto(travelogue, countLikes, isLiked, isBookmarked, isWriter);
   }
@@ -98,5 +98,9 @@ public class TravelogueService {
       TravelogueSearchFilter searchFilter) {
     return TravelogueCustomSlice.toDto(
         travelogueRepository.filtering(keyword, pageable, searchFilter));
+  }
+
+  private boolean isWriter(Member writer, Long requestMemberId) {
+    return Objects.equals(writer.getId(), requestMemberId);
   }
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/service/TravelogueServiceTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/service/TravelogueServiceTest.java
@@ -157,7 +157,7 @@ class TravelogueServiceTest {
         true,
         memberId);
     TravelogueDetailRes actualTravelogueDetail = TravelogueDetailRes.toDto(travelogue, countLikes,
-        isLiked, isBookmarked);
+        isLiked, isBookmarked, false);
 
     assertThat(actualTravelogueDetail).isEqualTo(expectedTravelogueDetail);
   }

--- a/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
@@ -239,6 +239,8 @@ class MemberMyTravelogueControllerTest {
                 parameterWithName("subTravelogueId").description("subTravelogue pk 값")
             ),
             responseFields(
+                fieldWithPath("subTravelogueId").type(JsonFieldType.NUMBER)
+                    .description("SubTravelogue PK 값"),
                 fieldWithPath("title").type(JsonFieldType.STRING)
                     .description("SubTravelogue 제목"),
                 fieldWithPath("content").type(JsonFieldType.STRING).description("subTravelogue 내용"),

--- a/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
@@ -203,9 +203,8 @@ class MemberMyTravelogueControllerTest {
             responseFields(
                 fieldWithPath("title").type(JsonFieldType.STRING)
                     .description("Travelogue 제목"),
-                fieldWithPath("period.startDate").type(JsonFieldType.ARRAY).description("여행 시작일"),
-                fieldWithPath("period.endDate").type(JsonFieldType.ARRAY).description("여행 종료일"),
-                fieldWithPath("period.nights").type(JsonFieldType.NUMBER).description("숙박일"),
+                fieldWithPath("period.startDate").type(JsonFieldType.STRING).description("여행 시작일"),
+                fieldWithPath("period.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                 fieldWithPath("country.name").type(JsonFieldType.STRING).description("방문한 나라"),
                 fieldWithPath("cost.transportation").type(JsonFieldType.NUMBER).description("교통비"),
                 fieldWithPath("cost.lodge").type(JsonFieldType.NUMBER).description("숙박비"),

--- a/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
@@ -268,6 +268,8 @@ class TravelogueControllerTest {
                     .description("작성자 여부"),
                 fieldWithPath("subTravelogues[]").type(JsonFieldType.ARRAY)
                     .description("SubTravelogue 리스트"),
+                fieldWithPath("subTravelogues[].subTravelogueId").type(JsonFieldType.NUMBER)
+                    .description("SubTravelogue PK 값"),
                 fieldWithPath("subTravelogues[].title").type(JsonFieldType.STRING)
                     .description("SubTravelogue의 제목"),
                 fieldWithPath("subTravelogues[].content").type(JsonFieldType.STRING)

--- a/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +32,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -266,6 +264,8 @@ class TravelogueControllerTest {
                     .description("좋아요 여부"),
                 fieldWithPath("bookmarked").type(JsonFieldType.BOOLEAN)
                     .description("북마크 여부"),
+                fieldWithPath("isWriter").type(JsonFieldType.BOOLEAN)
+                    .description("작성자 여부"),
                 fieldWithPath("subTravelogues[]").type(JsonFieldType.ARRAY)
                     .description("SubTravelogue 리스트"),
                 fieldWithPath("subTravelogues[].title").type(JsonFieldType.STRING)


### PR DESCRIPTION
### Response
```
{
    "profileImageUrl": "default",
    "nickname": "프로여행러",
    "id": 1,
    "title": "일본 오사카 여행기",
    "country": "일본",
    "nights": 0,
    "days": 1,
    "totalCost": 400000,
    "thumbnail": "www.naver.com",
    "subTravelogues": [
        {
            "title": "오사카 유니버셜 스튜디오 꿀팁 드려요.",
            "content": "오사카 유니버셜 스튜디오는 오픈런하셔야 해요. 그리고 오픈하자마자 해리포터로 달려가세요.",
            "day": 1,
            "addresses": [
                {
                    "region": "일본 오사카 유니버셜 스튜디오 재팬"
                }
            ],
            "transportationSet": [
                "SUBWAY"
            ],
            "travelPhotoCreateReqs": [
                {
                    "url": "www.google.com"
                }
            ]
        }
    ],
    "transportations": [
        "SUBWAY"
    ],
    "countLikes": 0,
    "isLiked": false,
    "viewCount": 1,
    "bookmarked": false,
    "isWriter": true
}
```
## 개발 내용 한줄 요약
> 개발한 내용을 한줄로 요약해주세요.

요청한 사용자가 작성자인지를 나타내는 필드를 추가하였습니다.

## 관련 이슈
> 관련 이슈를 작성해주세요
- #102 

<!--
## 리마인더 (주석처리)
[]본인의 로컬에서 정상 동작하는지 확인해주세요.
[]최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
[]API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
[]Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
[]commit 메시지 제대로 작성해주세요.
-->

## 코드리뷰 룰
R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
C(Comment): 웬만하면 고려해주시면 좋겠습니다.
A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
