### PR TITLE
♻️refactor: 임시 저장 게시글 전체 조회시 서브트래블로그 아이디들 반환하도록 수정

### DIFF
--- a/src/main/java/shop/zip/travel/domain/member/dto/response/MemberSimpleRes.java
+++ b/src/main/java/shop/zip/travel/domain/member/dto/response/MemberSimpleRes.java
@@ -1,16 +1,24 @@
 package shop.zip.travel.domain.member.dto.response;
 
+import shop.zip.travel.domain.member.entity.Member;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
 
 public record MemberSimpleRes(
-	String nickname,
-	String profileImageUrl
+		String nickname,
+		String profileImageUrl
 ) {
 
-	public static MemberSimpleRes toDto(TravelogueSimple travelogueSimple){
+	public static MemberSimpleRes toDto(TravelogueSimple travelogueSimple) {
 		return new MemberSimpleRes(
-			travelogueSimple.memberNickname(),
-			travelogueSimple.memberProfileImageUrl()
+				travelogueSimple.memberNickname(),
+				travelogueSimple.memberProfileImageUrl()
+		);
+	}
+
+	public static MemberSimpleRes toDto(Member member) {
+		return new MemberSimpleRes(
+				member.getNickname(),
+				member.getProfileImageUrl()
 		);
 	}
 }

--- a/src/main/java/shop/zip/travel/domain/post/image/dto/TravelPhotoCreateReq.java
+++ b/src/main/java/shop/zip/travel/domain/post/image/dto/TravelPhotoCreateReq.java
@@ -15,7 +15,7 @@ public record TravelPhotoCreateReq(
 
     public static TravelPhotoCreateReq toDto(TravelPhoto travelPhoto) {
         return new TravelPhotoCreateReq(
-            travelPhoto.getUrl()
+            DefaultValue.STRING.isEqual(travelPhoto.getUrl()) ? "" : travelPhoto.getUrl()
         );
     }
 }

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/AddressRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/AddressRes.java
@@ -1,0 +1,15 @@
+package shop.zip.travel.domain.post.subTravelogue.dto.res;
+
+import shop.zip.travel.domain.post.data.DefaultValue;
+import shop.zip.travel.domain.post.subTravelogue.data.Address;
+
+public record AddressRes(
+    String region
+) {
+
+  public static AddressRes toDto(Address address) {
+    return new AddressRes(
+        DefaultValue.STRING.isEqual(address.getRegion()) ? "" : address.getRegion()
+    );
+  }
+}

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/res/SubTravelogueDetailRes.java
@@ -2,8 +2,8 @@ package shop.zip.travel.domain.post.subTravelogue.dto.res;
 
 import java.util.List;
 import java.util.Set;
+import shop.zip.travel.domain.post.data.DefaultValue;
 import shop.zip.travel.domain.post.image.dto.TravelPhotoCreateReq;
-import shop.zip.travel.domain.post.subTravelogue.data.Address;
 import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 
@@ -12,7 +12,7 @@ public record SubTravelogueDetailRes(
     String title,
     String content,
     int day,
-    List<Address> addresses,
+    List<AddressRes> addresses,
     Set<Transportation> transportationSet,
     List<TravelPhotoCreateReq> travelPhotoCreateReqs
 ) {
@@ -20,10 +20,14 @@ public record SubTravelogueDetailRes(
     public static SubTravelogueDetailRes toDto(SubTravelogue subTravelogue) {
         return new SubTravelogueDetailRes(
             subTravelogue.getId(),
-            subTravelogue.getTitle(),
-            subTravelogue.getContent(),
+            DefaultValue.STRING.isEqual(subTravelogue.getTitle()) ? "" : subTravelogue.getTitle(),
+            DefaultValue.STRING.isEqual(subTravelogue.getContent()) ? ""
+                : subTravelogue.getContent(),
             subTravelogue.getDay(),
-            subTravelogue.getAddresses(),
+            subTravelogue.getAddresses()
+                .stream()
+                .map(AddressRes::toDto)
+                .toList(),
             subTravelogue.getTransportationSet(),
             subTravelogue.getPhotos()
                 .stream()

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TempTravelogueSimple.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TempTravelogueSimple.java
@@ -1,0 +1,10 @@
+package shop.zip.travel.domain.post.travelogue.dto;
+
+import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+
+public record TempTravelogueSimple(
+    Travelogue travelogue,
+    Long likeCount
+) {
+
+}

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TempTravelogueSimpleRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TempTravelogueSimpleRes.java
@@ -1,0 +1,53 @@
+package shop.zip.travel.domain.post.travelogue.dto.res;
+
+import java.util.ArrayList;
+import java.util.List;
+import shop.zip.travel.domain.member.dto.response.MemberSimpleRes;
+import shop.zip.travel.domain.member.entity.Member;
+import shop.zip.travel.domain.post.data.DefaultValue;
+import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
+import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+
+public record TempTravelogueSimpleRes(
+    Long travelogueId,
+    String title,
+    Long nights,
+    Long days,
+    Long totalCost,
+    String country,
+    String thumbnail,
+    MemberSimpleRes member,
+    Long likeCount,
+    List<Long> subTravelogueId
+) {
+
+  public static TempTravelogueSimpleRes toDto(TempTravelogueSimple travelogueSimple) {
+    Travelogue travelogue = travelogueSimple.travelogue();
+    long nights = travelogueSimple.travelogue().getPeriod().getNights();
+    Member member = travelogue.getMember();
+
+    List<Long> subIdList = new ArrayList<>();
+
+    if (!travelogue.getSubTravelogues().isEmpty()) {
+      subIdList = travelogue.getSubTravelogues()
+          .stream()
+          .map(SubTravelogue::getId)
+          .toList();
+    }
+
+    return new TempTravelogueSimpleRes(
+        travelogue.getId(),
+        DefaultValue.STRING.isEqual(travelogue.getTitle()) ? "" : travelogue.getTitle(),
+        nights,
+        nights + 1,
+        travelogue.getCost().getTotal(),
+        DefaultValue.STRING.isEqual(travelogue.getCountry().getName()) ? ""
+            : travelogue.getCountry().getName(),
+        DefaultValue.STRING.isEqual(travelogue.getThumbnail()) ? "" : travelogue.getThumbnail(),
+        MemberSimpleRes.toDto(member),
+        travelogueSimple.likeCount(),
+        subIdList
+    );
+  }
+}

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepository.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 import shop.zip.travel.domain.post.travelogue.repository.querydsl.TravelogueRepositoryQuerydsl;
@@ -50,16 +51,17 @@ public interface TravelogueRepository extends JpaRepository<Travelogue, Long>,
       @Param("isPublished") boolean isPublished);
 
   @Query(
-      "select new shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple( "
-          + "t.id, t.title, t.period, t.cost.total, t.country.name, t.thumbnail, m.nickname, m.profileImageUrl, count(l))"
+      "select new shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple( "
+          + "t, count(l)) "
           + "from Travelogue t "
           + "inner join t.member m "
           + "left join Like l "
           + "on l.travelogue.id = t.id "
           + "where m.id = :memberId and t.isPublished = :isPublished "
           + "group by t.id")
-  Slice<TravelogueSimple> getMyTempTravelogues(
+  Slice<TempTravelogueSimple> getMyTempTravelogues(
       @Param("memberId") Long memberId,
       @Param("pageable") Pageable pageable,
       @Param("isPublished") boolean isPublished);
+
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueMyTempService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueMyTempService.java
@@ -4,9 +4,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.res.TempTravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
-import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.repository.TravelogueRepository;
 
 @Service
@@ -22,13 +22,13 @@ public class TravelogueMyTempService {
     this.travelogueRepository = travelogueRepository;
   }
 
-  public TravelogueCustomSlice<TravelogueSimpleRes> getMyTempTravelogues(Long memberId,
+  public TravelogueCustomSlice<TempTravelogueSimpleRes> getMyTempTravelogues(Long memberId,
       Pageable pageable) {
-    Slice<TravelogueSimple> travelogues =
+    Slice<TempTravelogueSimple> travelogues =
         travelogueRepository.getMyTempTravelogues(memberId, pageable, TEMP);
 
     return TravelogueCustomSlice.toDto(
-        travelogues.map(TravelogueSimpleRes::toDto)
+        travelogues.map(TempTravelogueSimpleRes::toDto)
     );
   }
 }

--- a/src/main/java/shop/zip/travel/presentation/member/MemberMyTravelogueController.java
+++ b/src/main/java/shop/zip/travel/presentation/member/MemberMyTravelogueController.java
@@ -16,6 +16,7 @@ import shop.zip.travel.domain.post.subTravelogue.dto.req.SubTravelogueUpdateReq;
 import shop.zip.travel.domain.post.subTravelogue.dto.res.SubTravelogueDetailRes;
 import shop.zip.travel.domain.post.subTravelogue.dto.res.SubTravelogueUpdateRes;
 import shop.zip.travel.domain.post.travelogue.dto.req.TravelogueUpdateReq;
+import shop.zip.travel.domain.post.travelogue.dto.res.TempTravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueDetailForUpdateRes;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
@@ -50,10 +51,10 @@ public class MemberMyTravelogueController {
   }
 
   @GetMapping("/temp")
-  public ResponseEntity<TravelogueCustomSlice<TravelogueSimpleRes>> getTempAll(
+  public ResponseEntity<TravelogueCustomSlice<TempTravelogueSimpleRes>> getTempAll(
       @PageableDefault(size = DEFAULT_SIZE) Pageable pageable,
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
-    TravelogueCustomSlice<TravelogueSimpleRes> travelogueSimpleResList =
+    TravelogueCustomSlice<TempTravelogueSimpleRes> travelogueSimpleResList =
         travelogueTempService.getMyTempTravelogues(userPrincipal.getUserId(), pageable);
 
     return ResponseEntity.ok(travelogueSimpleResList);

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
@@ -19,6 +19,7 @@ import shop.zip.travel.domain.post.travelogue.data.Cost;
 import shop.zip.travel.domain.post.travelogue.data.Period;
 import shop.zip.travel.domain.post.travelogue.data.temp.TempCost;
 import shop.zip.travel.domain.post.travelogue.data.temp.TempPeriod;
+import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
 import shop.zip.travel.domain.post.travelogue.dto.req.TravelogueUpdateReq;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
@@ -276,5 +277,9 @@ public class DummyGenerator {
 
   public static SubTravelogue createFakeSubTravelogue(Long id, int day) {
     return new FakeSubTravelogue(id, createSubTravelogue(day));
+  }
+
+  public static TempTravelogueSimple createTempTravelogueSimple(Travelogue travelogue) {
+    return new TempTravelogueSimple(travelogue, 256L);
   }
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/service/TravelogueMyTempServiceTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/service/TravelogueMyTempServiceTest.java
@@ -20,9 +20,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import shop.zip.travel.domain.member.entity.Member;
 import shop.zip.travel.domain.post.travelogue.DummyGenerator;
-import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.res.TempTravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
-import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 import shop.zip.travel.domain.post.travelogue.repository.TravelogueRepository;
 
@@ -42,9 +42,9 @@ class TravelogueMyTempServiceTest {
     Member member = DummyGenerator.createMember();
     Travelogue travelogue = DummyGenerator.createTravelogue(member);
 
-    List<TravelogueSimple> travelogues = List.of(
-        DummyGenerator.createTravelogueSimple(travelogue),
-        DummyGenerator.createTravelogueSimple(travelogue)
+    List<TempTravelogueSimple> travelogues = List.of(
+        DummyGenerator.createTempTravelogueSimple(travelogue),
+        DummyGenerator.createTempTravelogueSimple(travelogue)
     );
 
     PageRequest pageRequest = PageRequest.of(
@@ -53,7 +53,7 @@ class TravelogueMyTempServiceTest {
         Sort.by(Direction.DESC, "createDate")
     );
 
-    Slice<TravelogueSimple> actual = new SliceImpl<>(
+    Slice<TempTravelogueSimple> actual = new SliceImpl<>(
         travelogues,
         pageRequest,
         pageRequest.next().isPaged()
@@ -65,7 +65,7 @@ class TravelogueMyTempServiceTest {
 
     // when
     Long memberId = 1L;
-    TravelogueCustomSlice<TravelogueSimpleRes> result =
+    TravelogueCustomSlice<TempTravelogueSimpleRes> result =
         travelogueTempService.getMyTempTravelogues(memberId, pageRequest);
 
     // then

--- a/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/member/MemberMyTravelogueControllerTest.java
@@ -164,8 +164,12 @@ class MemberMyTravelogueControllerTest {
                     .description("작성자 닉네임"),
                 fieldWithPath("content[].member.profileImageUrl").type(JsonFieldType.STRING)
                     .description("작성자 프로필 이미지 URL"),
+                fieldWithPath("content[].member.profileImageUrl").type(JsonFieldType.STRING)
+                    .description("작성자 프로필 이미지 URL"),
                 fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER)
-                    .description("게시글 좋아요 수"),
+                    .description("좋아요 수"),
+                fieldWithPath("content[].subTravelogueId[]").type(JsonFieldType.ARRAY)
+                    .description("Travelogue 가 가진 subTravelogue Id 리스트"),
                 fieldWithPath("pageable.sort.empty").description("데이터가 비어있는지에 대한 여부"),
                 fieldWithPath("pageable.sort.sorted").description("데이터가 정렬되어있는지에 대한 여부"),
                 fieldWithPath("pageable.sort.unsorted").description("데이터가 정렬되어 있지 않은지에 대한 여부"),


### PR DESCRIPTION
### Response
![스크린샷 2023-03-15 01 18 23](https://user-images.githubusercontent.com/75114420/225070061-ae2ff438-fc79-4b15-8226-2bd71d8b07cc.png)

## 개발 내용 한줄 요약
> 개발한 내용을 한줄로 요약해주세요.

임시저장한 게시글 목록을 조회할 때 가지고 있는 서브 트래블로그 아이디들을 반환하도록 수정하였습니다.


## 집중적인 코드리뷰
> 좀 더 상세하게 리뷰 받고 싶은 부분을 기재해주세요.


<!--
## 리마인더 (주석처리)
[]본인의 로컬에서 정상 동작하는지 확인해주세요.
[]최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
[]API가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
[]Conflict가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
[]commit 메시지 제대로 작성해주세요.
-->

## 코드리뷰 룰
R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
C(Comment): 웬만하면 고려해주시면 좋겠습니다.
A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
