### PR TITLE
연관관계 양방향 매핑(+수린)

### DIFF
--- a/src/main/java/shop/zip/travel/domain/post/image/entity/TravelPhoto.java
+++ b/src/main/java/shop/zip/travel/domain/post/image/entity/TravelPhoto.java
@@ -2,10 +2,14 @@ package shop.zip.travel.domain.post.image.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import org.springframework.util.Assert;
+import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 
 @Entity
 public class TravelPhoto {
@@ -19,12 +23,20 @@ public class TravelPhoto {
     @Column(nullable = false)
     private String url;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sub_travelogue_id")
+    private SubTravelogue subTravelogue;
+
     protected TravelPhoto() {
     }
 
     public TravelPhoto(String url) {
         verify(url);
         this.url = url;
+    }
+
+    public void updateSubTravelogue(SubTravelogue subTravelogue) {
+        this.subTravelogue = subTravelogue;
     }
 
     public Long getId() {

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/req/SubTravelogueCreateReq.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/dto/req/SubTravelogueCreateReq.java
@@ -33,7 +33,7 @@ public record SubTravelogueCreateReq(
         );
     }
 
-    private List<TravelPhoto> toTravelPhotos() {
+    public List<TravelPhoto> toTravelPhotos() {
         if (Objects.isNull(travelPhotoCreateReqs)) {
             return new ArrayList<>();
         }

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/entity/SubTravelogue.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/entity/SubTravelogue.java
@@ -1,6 +1,5 @@
 package shop.zip.travel.domain.post.subTravelogue.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -12,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -23,6 +23,7 @@ import shop.zip.travel.domain.post.image.entity.TravelPhoto;
 import shop.zip.travel.domain.post.subTravelogue.data.Address;
 import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 import shop.zip.travel.domain.post.subTravelogue.dto.SubTravelogueUpdate;
+import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 import shop.zip.travel.domain.post.travelogue.exception.InvalidPublishTravelogueException;
 import shop.zip.travel.global.error.ErrorCode;
 
@@ -56,9 +57,12 @@ public class SubTravelogue extends BaseTimeEntity {
     @Column(nullable = false)
     private Set<Transportation> transportationSet = new HashSet<>();
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "sub_travelogue_id")
+    @OneToMany(mappedBy = "subTravelogue")
     private List<TravelPhoto> photos = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travelogue_id")
+    private Travelogue travelogue;
 
     protected SubTravelogue() {
     }
@@ -77,6 +81,10 @@ public class SubTravelogue extends BaseTimeEntity {
         this.addresses = addresses;
         this.transportationSet = transportationSet;
         this.photos = photos;
+    }
+
+    public Travelogue getTravelogue() {
+        return travelogue;
     }
 
     public Long getId() {
@@ -105,6 +113,25 @@ public class SubTravelogue extends BaseTimeEntity {
 
     public List<TravelPhoto> getPhotos() {
         return new ArrayList<>(photos);
+    }
+
+
+    public void updateTravelogue(Travelogue travelogue) {
+        if(travelogue!=null) {
+            this.travelogue = travelogue;
+            travelogue.addSubTravelogue(this);
+        }
+    }
+
+    public void addTravelPhotos(List<TravelPhoto> travelPhotos) {
+        travelPhotos.forEach(this::addTraveloguePhoto);
+    }
+
+    public void addTraveloguePhoto(TravelPhoto travelPhoto) {
+        if(travelPhoto!= null) {
+            travelPhoto.updateSubTravelogue(this);
+            this.photos.add(travelPhoto);
+        }
     }
 
     private void verify(String title,

--- a/src/main/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/subTravelogue/service/SubTravelogueService.java
@@ -29,25 +29,25 @@ public class SubTravelogueService {
         Travelogue travelogue = travelogueService.getTravelogue(travelogueId);
         SubTravelogue subTravelogue = subTravelogueRepository.save(createReq.toSubTravelogue());
 
-        addPhotosTo(subTravelogue, createReq);
-
-        travelogue.addSubTravelogue(subTravelogue);
+        subTravelogue.updateTravelogue(travelogue);
+        subTravelogue.addTravelPhotos(createReq.toTravelPhotos());
 
         return new SubTravelogueCreateRes(subTravelogue.getId());
     }
 
-    private void addPhotosTo(
-        SubTravelogue subTravelogue,
-        SubTravelogueCreateReq subTravelogueCreateReq
-    ) {
-        if (subTravelogue.getPhotos().isEmpty()) {
-            return;
-        }
-
-        subTravelogue.getPhotos()
-            .addAll(subTravelogueCreateReq.travelPhotoCreateReqs()
-                .stream()
-                .map(TravelPhotoCreateReq::toEntity)
-                .toList());
-    }
+//    private void addPhotosTo(
+//        SubTravelogue subTravelogue,
+//        SubTravelogueCreateReq subTravelogueCreateReq
+//    ) {
+//        if (subTravelogue.getPhotos().isEmpty()) {
+//            return;
+//        }
+//
+//
+//        subTravelogue.getPhotos()
+//            .addAll(subTravelogueCreateReq.travelPhotoCreateReqs()
+//                .stream()
+//                .map(TravelPhotoCreateReq::toEntity)
+//                .toList());
+//    }
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
@@ -1,6 +1,5 @@
 package shop.zip.travel.domain.post.travelogue.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -63,8 +62,7 @@ public class Travelogue extends BaseTimeEntity {
   @Column(nullable = false)
   private Long viewCount;
 
-  @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
-  @JoinColumn(name = "travelogue_id")
+  @OneToMany(mappedBy = "travelogue")
   private List<SubTravelogue> subTravelogues = new ArrayList<>();
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
@@ -79,7 +79,8 @@ public class TravelogueService {
         .orElseThrow(() -> new TravelogueNotFoundException(ErrorCode.TRAVELOGUE_NOT_FOUND));
 
     updateViewCount(travelogueId, canAddViewCount);
-    Suggestion suggestion = new Suggestion(travelogue, memberId);
+
+    Suggestion suggestion = new Suggestion(travelogue.getCountry().getName(), memberId);
     suggestionRepository.save(suggestion);
 
     boolean isWriter = isWriter(travelogue.getMember(), memberId);

--- a/src/main/java/shop/zip/travel/domain/suggestion/entity/Suggestion.java
+++ b/src/main/java/shop/zip/travel/domain/suggestion/entity/Suggestion.java
@@ -1,14 +1,8 @@
 package shop.zip.travel.domain.suggestion.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
-import shop.zip.travel.domain.base.BaseTimeEntity;
-import shop.zip.travel.domain.member.entity.Member;
-import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 
 @RedisHash(timeToLive = 60 * 60 * 24 * 7)
 public class Suggestion {
@@ -16,7 +10,7 @@ public class Suggestion {
   @Id
   private String id;
 
-  private Travelogue travelogue;
+  private String countryName;
 
   @Indexed
   private Long memberId;
@@ -24,13 +18,13 @@ public class Suggestion {
   protected Suggestion() {
   }
 
-  public Suggestion(Travelogue travelogue, Long memberId) {
-    this.travelogue = travelogue;
+  public Suggestion(String country, Long memberId) {
+    this.countryName = country;
     this.memberId = memberId;
   }
 
-  public Travelogue getTravelogue() {
-    return travelogue;
+  public String getCountryName() {
+    return countryName;
   }
 
   public Long getMemberId() {

--- a/src/main/java/shop/zip/travel/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/shop/zip/travel/domain/suggestion/service/SuggestionService.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
-import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 import shop.zip.travel.domain.post.travelogue.service.TravelogueService;
 import shop.zip.travel.domain.suggestion.entity.Suggestion;
 import shop.zip.travel.domain.suggestion.repository.SuggestionRepository;
@@ -35,34 +33,28 @@ public class SuggestionService {
   }
 
   @Transactional
-  public void save(Travelogue travelogue, Long memberId) {
-    Suggestion suggestion = new Suggestion(travelogue, memberId);
+  public void save(String countryName, Long memberId) {
+    Suggestion suggestion = new Suggestion(countryName, memberId);
 
     suggestionRepository.save(suggestion);
   }
 
   @Transactional
-  public TravelogueCustomSlice<TravelogueSimpleRes> findByMemberId(Long memberId, Pageable pageable) {
+  public TravelogueCustomSlice<TravelogueSimpleRes> findByMemberId(Long memberId,
+      Pageable pageable) {
     List<Suggestion> suggestions = suggestionRepository.getSuggestionByMemberId(memberId);
     Map<String, Long> map = new HashMap<>();
 
     map.put("대한민국", 1L);
 
-    suggestions.forEach(suggestion-> {
-      System.out.println("suggestions 만들어짐 ");
-      String keyword = suggestion.getTravelogue().getCountry().getName();
+    suggestions.forEach(suggestion -> {
+      String keyword = suggestion.getCountryName();
       map.put(keyword, map.getOrDefault(keyword, 0L) + 1);
     });
 
-    Comparator<Entry<String, Long>> comparator = new Comparator<Entry<String, Long>>() {
-      @Override
-      public int compare(Entry<String, Long> e1, Entry<String, Long> e2) {
-        return e1.getValue().compareTo(e2.getValue());
-      }
-    };
+    Comparator<Entry<String, Long>> comparator = Comparator.comparing(Entry::getValue);
 
     Entry<String, Long> maxEntry = Collections.max(map.entrySet(), comparator);
-    log.error("maxEntry.getValue() : " + maxEntry.getValue());
 
     return travelogueService.search(maxEntry.getKey(), pageable);
   }

--- a/src/main/java/shop/zip/travel/presentation/suggestion/SuggestionController.java
+++ b/src/main/java/shop/zip/travel/presentation/suggestion/SuggestionController.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
@@ -59,16 +59,19 @@ public class DummyGenerator {
 
   public static Travelogue createTravelogueWithSubTravelogues(List<SubTravelogue> subTravelogues,
       Member member) {
-    return new Travelogue(
+    Travelogue travelogue1 = new Travelogue(
         createPeriod(),
         "일본 오사카 다녀왔어요.",
         createCountry(),
         "www.naver.com",
         createCost(),
         true,
-        subTravelogues,
         member
     );
+
+    subTravelogues.forEach(i-> i.updateTravelogue(travelogue1));
+
+    return travelogue1;
   }
 
 

--- a/src/test/java/shop/zip/travel/presentation/travelogue/TempTravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/travelogue/TempTravelogueControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.zip.travel.domain.member.entity.Member;
 import shop.zip.travel.domain.member.repository.MemberRepository;
 import shop.zip.travel.domain.post.subTravelogue.dto.req.SubTravelogueUpdateReq;
+import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
+import shop.zip.travel.domain.post.subTravelogue.repository.SubTravelogueRepository;
 import shop.zip.travel.domain.post.travelogue.DummyGenerator;
 import shop.zip.travel.domain.post.travelogue.dto.req.TravelogueUpdateReq;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
@@ -55,6 +58,9 @@ class TempTravelogueControllerTest {
   private TravelogueRepository travelogueRepository;
 
   @Autowired
+  private SubTravelogueRepository subTravelogueRepository;
+
+  @Autowired
   private MemberRepository memberRepository;
 
   @Autowired
@@ -67,7 +73,9 @@ class TempTravelogueControllerTest {
   @BeforeEach
   void setUp() {
     member = memberRepository.save(DummyGenerator.createMember());
-    travelogue = travelogueRepository.save(DummyGenerator.createTravelogue(member));
+    List<SubTravelogue> subTravelogues = Arrays.asList(DummyGenerator.createSubTravelogue(1), DummyGenerator.createSubTravelogue(2));
+    subTravelogueRepository.saveAll(subTravelogues);
+    travelogue = travelogueRepository.save(DummyGenerator.createTravelogueWithSubTravelogues(subTravelogues, member));
     token = "Bearer " + jwtTokenProvider.createAccessToken(member.getId());
   }
 


### PR DESCRIPTION
연관관계 일대다 에서 양방향으로 변경하였습니다 (수린님이랑 페어프로그래밍 했습니다) 

이유: 삽입, 수정, 삭제 시 update쿼리 나가는 것 방지, 검색쿼리 리팩토링시 쿼리 성능 향상을 위해서 

