### PR TITLE
[Feature/#130] 상세보기와 조회수 Update 로직 분리 + 누락된 검색기능 리팩토링 추가

### DIFF
--- a/src/main/java/shop/zip/travel/TravelApplication.java
+++ b/src/main/java/shop/zip/travel/TravelApplication.java
@@ -2,9 +2,7 @@ package shop.zip.travel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class TravelApplication {
 

--- a/src/main/java/shop/zip/travel/domain/bookmark/repository/impl/BookmarkRepositoryImpl.java
+++ b/src/main/java/shop/zip/travel/domain/bookmark/repository/impl/BookmarkRepositoryImpl.java
@@ -34,18 +34,6 @@ public class BookmarkRepositoryImpl extends QuerydslRepositorySupport
   }
 
   @Override
-  public boolean exists(Long memberId, Long travelogueId) {
-    Integer bookmarked = jpaQueryFactory
-        .selectOne()
-        .from(bookmark)
-        .where(bookmark.travelogue.id.eq(travelogueId)
-            .and(bookmark.member.id.eq(memberId)))
-        .fetchFirst();
-
-    return bookmarked != null;
-  }
-
-  @Override
   public Slice<TravelogueSimpleRes> getBookmarkedList(Long memberId, Pageable pageable) {
     List<Long> travelogueIds = getTraveloguesBy(memberId);
 
@@ -114,5 +102,6 @@ public class BookmarkRepositoryImpl extends QuerydslRepositorySupport
         .map(TravelogueSimpleRes::toDto)
         .toList(), pageable, hasNext);
   }
+
 
 }

--- a/src/main/java/shop/zip/travel/domain/bookmark/repository/querydsl/BookmarkRepositoryQuerydsl.java
+++ b/src/main/java/shop/zip/travel/domain/bookmark/repository/querydsl/BookmarkRepositoryQuerydsl.java
@@ -7,7 +7,5 @@ import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 
 public interface BookmarkRepositoryQuerydsl {
 
-  boolean exists(Long memberId, Long travelogueId);
-
   Slice<TravelogueSimpleRes> getBookmarkedList(Long memberId, Pageable pageable);
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TravelogueSimpleDetail.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TravelogueSimpleDetail.java
@@ -1,0 +1,15 @@
+package shop.zip.travel.domain.post.travelogue.dto;
+
+import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+
+public record TravelogueSimpleDetail(
+    Travelogue travelogue,
+    Long memberId,
+    String profileImageUrl,
+    String nickName,
+    long countLikes,
+    boolean isLiked,
+    boolean isBookmarked
+) {
+
+}

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TravelogueSimpleDetail.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/TravelogueSimpleDetail.java
@@ -1,5 +1,7 @@
 package shop.zip.travel.domain.post.travelogue.dto;
 
+import java.util.List;
+import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 
 public record TravelogueSimpleDetail(
@@ -9,7 +11,9 @@ public record TravelogueSimpleDetail(
     String nickName,
     long countLikes,
     boolean isLiked,
-    boolean isBookmarked
+    boolean isBookmarked,
+    long viewsId,
+    List<SubTravelogue> subTravelogues
 ) {
 
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import shop.zip.travel.domain.post.subTravelogue.data.Transportation;
 import shop.zip.travel.domain.post.subTravelogue.dto.res.SubTravelogueDetailRes;
 import shop.zip.travel.domain.post.subTravelogue.entity.SubTravelogue;
-import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimpleDetail;
 
 public record TravelogueDetailRes(
     String profileImageUrl,
@@ -21,46 +21,42 @@ public record TravelogueDetailRes(
     String thumbnail,
     List<SubTravelogueDetailRes> subTravelogues,
     Set<Transportation> transportations,
-    Long countLikes,
+    long countLikes,
     boolean isLiked,
-    Long viewCount,
-    Boolean bookmarked,
+    long viewCount,
+    boolean bookmarked,
     boolean isWriter
 ) {
 
-  public static TravelogueDetailRes toDto(
-      Travelogue travelogue,
-      Long countLikes,
-      Boolean isLiked,
-      Boolean isBookmarked,
+  public static TravelogueDetailRes toDto(TravelogueSimpleDetail simpleDetailDto,
       boolean isWriter
   ) {
+
     return new TravelogueDetailRes(
-        travelogue.getMember().getProfileImageUrl(),
-        travelogue.getMember().getNickname(),
-        travelogue.getId(),
-        travelogue.getTitle(),
-        travelogue.getCountry().getName(),
-        travelogue.getPeriod().getNights(),
-        travelogue.getPeriod().getNights() + 1,
-        travelogue.getCost().getTotal(),
-        travelogue.getThumbnail(),
-        travelogue.getSubTravelogues()
+        simpleDetailDto.profileImageUrl(),
+        simpleDetailDto.nickName(),
+        simpleDetailDto.travelogue().getId(),
+        simpleDetailDto.travelogue().getTitle(),
+        simpleDetailDto.travelogue().getCountry().getName(),
+        simpleDetailDto.travelogue().getPeriod().getNights(),
+        simpleDetailDto.travelogue().getPeriod().getNights() + 1,
+        simpleDetailDto.travelogue().getCost().getTotal(),
+        simpleDetailDto.travelogue().getThumbnail(),
+        simpleDetailDto.travelogue().getSubTravelogues()
             .stream()
             .map(SubTravelogueDetailRes::toDto)
             .toList(),
-        travelogue.getSubTravelogues()
+        simpleDetailDto.travelogue().getSubTravelogues()
             .stream()
             .map(SubTravelogue::getTransportationSet)
             .flatMap(Collection::stream)
             .collect(Collectors.toSet()),
-        countLikes,
-        isLiked,
-        travelogue.getViewCount(),
-        isBookmarked,
+        simpleDetailDto.countLikes(),
+        simpleDetailDto.isLiked(),
+        simpleDetailDto.travelogue().getViews().getCount(),
+        simpleDetailDto.isBookmarked(),
         isWriter
     );
-
   }
 
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/dto/res/TravelogueDetailRes.java
@@ -42,11 +42,11 @@ public record TravelogueDetailRes(
         simpleDetailDto.travelogue().getPeriod().getNights() + 1,
         simpleDetailDto.travelogue().getCost().getTotal(),
         simpleDetailDto.travelogue().getThumbnail(),
-        simpleDetailDto.travelogue().getSubTravelogues()
+        simpleDetailDto.subTravelogues()
             .stream()
             .map(SubTravelogueDetailRes::toDto)
             .toList(),
-        simpleDetailDto.travelogue().getSubTravelogues()
+        simpleDetailDto.subTravelogues()
             .stream()
             .map(SubTravelogue::getTransportationSet)
             .flatMap(Collection::stream)

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
@@ -1,5 +1,6 @@
 package shop.zip.travel.domain.post.travelogue.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -11,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -59,9 +61,6 @@ public class Travelogue extends BaseTimeEntity {
   @Column(nullable = false)
   private boolean isPublished;
 
-  @Column(nullable = false)
-  private Long viewCount;
-
   @OneToMany(mappedBy = "travelogue")
   private List<SubTravelogue> subTravelogues = new ArrayList<>();
 
@@ -69,21 +68,21 @@ public class Travelogue extends BaseTimeEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @JoinColumn(name = "views_id", referencedColumnName = "id")
+  private Views views;
+
   protected Travelogue() {
   }
 
   public Travelogue(Period period, String title, Country country, String thumbnail, Cost cost,
       boolean isPublished, Member member) {
-    this(period, title, country, thumbnail, cost, isPublished, 0L, new ArrayList<>(), member);
+    this(period, title, country, thumbnail, cost, isPublished, new ArrayList<>(), member,
+        new Views(0L));
   }
 
   public Travelogue(Period period, String title, Country country, String thumbnail, Cost cost,
-      boolean isPublished, List<SubTravelogue> subTravelogues, Member member) {
-    this(period, title, country, thumbnail, cost, isPublished, 0L, subTravelogues, member);
-  }
-
-  public Travelogue(Period period, String title, Country country, String thumbnail, Cost cost,
-      boolean isPublished, Long viewCount, List<SubTravelogue> subTravelogues, Member member) {
+      boolean isPublished, List<SubTravelogue> subTravelogues, Member member, Views views) {
     checkNull(member);
     this.period = period;
     this.title = title;
@@ -91,10 +90,11 @@ public class Travelogue extends BaseTimeEntity {
     this.thumbnail = thumbnail;
     this.cost = cost;
     this.isPublished = isPublished;
-    this.viewCount = viewCount;
     this.subTravelogues = subTravelogues;
     this.member = member;
+    this.views = views;
   }
+
 
   public Long getId() {
     return id;
@@ -120,10 +120,6 @@ public class Travelogue extends BaseTimeEntity {
     return thumbnail;
   }
 
-  public boolean getIsPublished() {
-    return isPublished;
-  }
-
   public List<SubTravelogue> getSubTravelogues() {
     return new ArrayList<>(subTravelogues);
   }
@@ -132,10 +128,13 @@ public class Travelogue extends BaseTimeEntity {
     return member;
   }
 
-  public Long getViewCount() {
-    return viewCount;
+  public Views getViews() {
+    return views;
   }
 
+  public boolean isPublished() {
+    return isPublished;
+  }
 
   public void addSubTravelogue(SubTravelogue subTravelogue) {
     verifySubTravelogueDuplicate(subTravelogue);
@@ -172,10 +171,6 @@ public class Travelogue extends BaseTimeEntity {
     if (!this.member.getId().equals(memberId)) {
       throw new NoAuthorizationException(ErrorCode.NO_AUTHORIZATION_TO_TRAVELOGUE);
     }
-  }
-
-  public void addViewCount() {
-    this.viewCount++;
   }
 
   public void updateSubTravelogues(SubTravelogue newSubTravelogue) {

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Travelogue.java
@@ -78,7 +78,7 @@ public class Travelogue extends BaseTimeEntity {
   public Travelogue(Period period, String title, Country country, String thumbnail, Cost cost,
       boolean isPublished, Member member) {
     this(period, title, country, thumbnail, cost, isPublished, new ArrayList<>(), member,
-        new Views(0L));
+        new Views(1L));
   }
 
   public Travelogue(Period period, String title, Country country, String thumbnail, Cost cost,

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Views.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/entity/Views.java
@@ -1,0 +1,34 @@
+package shop.zip.travel.domain.post.travelogue.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Views {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private long count;
+
+  public Views(long count) {
+    this.count = count;
+  }
+
+  protected Views() {
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+}

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepository.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepository.java
@@ -1,11 +1,8 @@
 package shop.zip.travel.domain.post.travelogue.repository;
 
-import jakarta.persistence.LockModeType;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,13 +27,6 @@ public interface TravelogueRepository extends JpaRepository<Travelogue, Long>,
   Slice<TravelogueSimple> findAllBySlice(
       @Param("pageable") Pageable pageable,
       @Param("isPublished") boolean isPublished);
-
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Query("select t "
-      + "from Travelogue t "
-      + "left join fetch t.member "
-      + "where t.id = :travelogueId and t.isPublished = true")
-  Optional<Travelogue> getTravelogueDetail(@Param("travelogueId") Long travelogueId);
 
   @Query(
       "select new shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple("

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueViewRepository.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueViewRepository.java
@@ -1,0 +1,20 @@
+package shop.zip.travel.domain.post.travelogue.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import shop.zip.travel.domain.post.travelogue.entity.Views;
+
+@Repository
+public interface TravelogueViewRepository extends JpaRepository<Views, Long> {
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("update Views v "
+      + "set v.count = v.count + 1 "
+      + "where v.id = :id ")
+  void increaseCount(@Param("id") Long id);
+
+}
+

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/impl/TravelogueRepositoryImpl.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/impl/TravelogueRepositoryImpl.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -56,8 +55,7 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
 
   @Override
   public Slice<TravelogueSimpleRes> search(String keyword, Pageable pageable) {
-    List<Long> subTravelogueIds = getSubTravelogueIds(keyword);
-    List<Long> travelogueIds = getTravelogueIds(keyword, subTravelogueIds);
+    List<Long> travelogueIds = getTravelogueIds(keyword);
 
     if (travelogueIds.isEmpty()) {
       return new SliceImpl<>(Collections.emptyList());
@@ -97,8 +95,7 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
   public Slice<TravelogueSimpleRes> filtering(String keyword, Pageable pageable,
       TravelogueSearchFilter searchFilter) {
 
-    List<Long> subTravelogueIds = getSubTravelogueIds(keyword);
-    List<Long> travelogueIds = getTravelogueIds(keyword, subTravelogueIds);
+    List<Long> travelogueIds = getTravelogueIds(keyword);
 
     if (travelogueIds.isEmpty()) {
       return new SliceImpl<>(Collections.emptyList());
@@ -143,97 +140,90 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
     return travelogue.isPublished.isTrue();
   }
 
-  private List<Long> getTravelogueIds(String keyword, List<Long> subTravelogueIds) {
-    return Stream.concat(getTravelogueIds_containsSubTravelogues(subTravelogueIds).stream(),
-            Stream.concat(getTravelogueIds_searchCountryName(keyword).stream(),
-                getTravelogueIds_containsTitleName(keyword).stream()))
-        .distinct()
-        .toList();
-  }
+//  private List<Long> getTravelogueIds(String keyword, List<Long> subTravelogueIds) {
+//    return Stream.concat(getTravelogueIds_containsSubTravelogues(subTravelogueIds).stream(),
+//            Stream.concat(getTravelogueIds_searchCountryName(keyword).stream(),
+//                getTravelogueIds_containsTitleName(keyword).stream()))
+//        .distinct()
+//        .toList();
+//  }
 
-  private List<Long> getTravelogueIds_containsSubTravelogues(
-      List<Long> subTravelogueIds
+  private List<Long> getTravelogueIds(
+      String keyword
   ) {
     return jpaQueryFactory
         .select(travelogue.id)
         .from(travelogue)
         .leftJoin(travelogue.subTravelogues, subTravelogue)
         .where(
-            publishedIsTrue(),
-            subTravelogue.id.in(subTravelogueIds)
+            publishedIsTrue().and(
+                subTravelogue.id.in(getSubTravelogueIds(keyword))
+                    .or(titleContains(keyword))
+                    .or(countryContains(keyword))
+            )
         )
+        .distinct()
         .fetch();
   }
 
-  private List<Long> getTravelogueIds_containsTitleName(String keyword) {
-    return jpaQueryFactory
-        .select(travelogue.id)
-        .from(travelogue)
-        .where(
-            publishedIsTrue(),
-            titleContains(keyword)
-        )
-        .fetch();
-  }
+//  private List<Long> getTravelogueIds_containsTitleName(String keyword) {
+//    return jpaQueryFactory
+//        .select(travelogue.id)
+//        .from(travelogue)
+//        .where(
+//            publishedIsTrue(),
+//            titleContains(keyword)
+//        )
+//        .fetch();
+//  }
 
-  private List<Long> getTravelogueIds_searchCountryName(
-      String keyword
-  ) {
-    return jpaQueryFactory
-        .select(travelogue.id)
-        .from(travelogue)
-        .where(
-            publishedIsTrue(),
-            countryContains(keyword)
-        )
-        .fetch();
-  }
+//  private List<Long> getTravelogueIds_searchCountryName(
+//      String keyword
+//  ) {
+//    return jpaQueryFactory
+//        .select(travelogue.id)
+//        .from(travelogue)
+//        .where(
+//            publishedIsTrue(),
+//            countryContains(keyword)
+//        )
+//        .fetch();
+//  }
 
   private List<Long> getSubTravelogueIds(String keyword) {
-    return Stream.concat(getSubTravelogueIds_containsContent(keyword).stream(),
-            getSubTravelogueIds_containsSpot(keyword).stream())
-        .distinct()
-        .toList();
-  }
-
-  private List<Long> getSubTravelogueIds_containsSpot(String keyword) {
     return jpaQueryFactory
         .select(subTravelogue.id)
         .from(subTravelogue)
         .innerJoin(subTravelogue.addresses, address)
         .where(
-            spotContains(keyword)
+            publishedIsTrue()
+                .and(spotContains(keyword)
+                    .or(subTitleContains(keyword))
+                    .or(contentContains(keyword))
+                )
         )
         .fetch();
   }
-
-  private List<Long> getSubTravelogueIds_containsContent(String keyword) {
-    return jpaQueryFactory
-        .select(subTravelogue.id)
-        .from(subTravelogue)
-        .innerJoin(subTravelogue.addresses, address)
-        .where(
-            contentContains(keyword)
-        )
-        .fetch();
-  }
-
 
   private BooleanExpression titleContains(String keyword) {
-    return hasText(keyword) ? travelogue.title.contains(keyword) : null;
+    return hasText(keyword) ? travelogue.title.startsWith(keyword) : null;
+  }
+
+  private BooleanExpression subTitleContains(String keyword) {
+    return hasText(keyword) ? subTravelogue.title.startsWith(keyword) : null;
   }
 
   private BooleanExpression countryContains(String keyword) {
-    return hasText(keyword) ? travelogue.country.name.contains(keyword) : null;
+    return hasText(keyword) ? travelogue.country.name.startsWith(keyword) : null;
   }
 
   private BooleanExpression contentContains(String keyword) {
-    return hasText(keyword) ? subTravelogue.content.contains(keyword) : null;
+    return hasText(keyword) ? subTravelogue.content.startsWith(keyword) : null;
   }
 
   private BooleanExpression spotContains(String keyword) {
     return hasText(keyword) ?
-        address.region.contains(keyword) : null;
+        address.region.startsWith(keyword) : null;
   }
 
   private OrderSpecifier<?> getOrder(Sort sort) {
@@ -326,7 +316,8 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
         .on(like.travelogue.id.eq(travelogue.id))
         .leftJoin(bookmark)
         .on(bookmark.travelogue.id.eq(travelogue.id))
-        .leftJoin(travelogue.views, views).fetchJoin()
+        .leftJoin(travelogue.views, views)
+        .fetchJoin()
         .leftJoin(travelogue.subTravelogues, subTravelogue)
         .where(travelogue.id.eq(travelogueId))
         .fetchOne());

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/impl/TravelogueRepositoryImpl.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/impl/TravelogueRepositoryImpl.java
@@ -140,14 +140,6 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
     return travelogue.isPublished.isTrue();
   }
 
-//  private List<Long> getTravelogueIds(String keyword, List<Long> subTravelogueIds) {
-//    return Stream.concat(getTravelogueIds_containsSubTravelogues(subTravelogueIds).stream(),
-//            Stream.concat(getTravelogueIds_searchCountryName(keyword).stream(),
-//                getTravelogueIds_containsTitleName(keyword).stream()))
-//        .distinct()
-//        .toList();
-//  }
-
   private List<Long> getTravelogueIds(
       String keyword
   ) {
@@ -165,30 +157,6 @@ public class TravelogueRepositoryImpl extends QuerydslRepositorySupport implemen
         .distinct()
         .fetch();
   }
-
-//  private List<Long> getTravelogueIds_containsTitleName(String keyword) {
-//    return jpaQueryFactory
-//        .select(travelogue.id)
-//        .from(travelogue)
-//        .where(
-//            publishedIsTrue(),
-//            titleContains(keyword)
-//        )
-//        .fetch();
-//  }
-
-//  private List<Long> getTravelogueIds_searchCountryName(
-//      String keyword
-//  ) {
-//    return jpaQueryFactory
-//        .select(travelogue.id)
-//        .from(travelogue)
-//        .where(
-//            publishedIsTrue(),
-//            countryContains(keyword)
-//        )
-//        .fetch();
-//  }
 
   private List<Long> getSubTravelogueIds(String keyword) {
     return jpaQueryFactory

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/repository/querydsl/TravelogueRepositoryQuerydsl.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/repository/querydsl/TravelogueRepositoryQuerydsl.java
@@ -1,8 +1,10 @@
 package shop.zip.travel.domain.post.travelogue.repository.querydsl;
 
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSearchFilter;
+import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimpleDetail;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 
 public interface TravelogueRepositoryQuerydsl {
@@ -13,8 +15,6 @@ public interface TravelogueRepositoryQuerydsl {
 
   Slice<TravelogueSimpleRes> search(String keyword, Pageable pageable);
 
-  boolean isLiked(Long travelogueId, Long memberId);
-
-  Long countLikes(Long travelogueId);
+  Optional<TravelogueSimpleDetail> getTravelogueDetail(Long travelogueId, Long memberId);
 }
 

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
@@ -72,10 +72,7 @@ public class TravelogueService {
     TravelogueDetailRes travelogueDetailRes =
         TravelogueDetailRes.toDto(simpleDetail, isWriter(simpleDetail.memberId(), memberId));
 
-    travelogueViewService.increase(simpleDetail.travelogue()
-            .getViews()
-            .getId(),
-        canAddViewCount);
+    travelogueViewService.increase(simpleDetail.viewsId(), canAddViewCount);
 
     return travelogueDetailRes;
   }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueService.java
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import shop.zip.travel.domain.bookmark.repository.BookmarkRepository;
 import shop.zip.travel.domain.member.entity.Member;
 import shop.zip.travel.domain.member.service.MemberService;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSearchFilter;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimpleDetail;
 import shop.zip.travel.domain.post.travelogue.dto.req.TravelogueCreateReq;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCreateRes;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueCustomSlice;
@@ -18,8 +18,6 @@ import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
 import shop.zip.travel.domain.post.travelogue.exception.TravelogueNotFoundException;
 import shop.zip.travel.domain.post.travelogue.repository.TravelogueRepository;
-import shop.zip.travel.domain.suggestion.entity.Suggestion;
-import shop.zip.travel.domain.suggestion.repository.SuggestionRepository;
 import shop.zip.travel.global.error.ErrorCode;
 
 @Service
@@ -29,16 +27,14 @@ public class TravelogueService {
   private static final boolean PUBLISH = true;
 
   private final TravelogueRepository travelogueRepository;
+  private final TravelogueViewService travelogueViewService;
   private final MemberService memberService;
-  private final BookmarkRepository bookmarkRepository;
-  private final SuggestionRepository suggestionRepository;
 
-  public TravelogueService(TravelogueRepository travelogueRepository, MemberService memberService,
-      BookmarkRepository bookmarkRepository, SuggestionRepository suggestionRepository) {
+  public TravelogueService(TravelogueRepository travelogueRepository,
+      TravelogueViewService travelogueViewService, MemberService memberService) {
     this.travelogueRepository = travelogueRepository;
+    this.travelogueViewService = travelogueViewService;
     this.memberService = memberService;
-    this.bookmarkRepository = bookmarkRepository;
-    this.suggestionRepository = suggestionRepository;
   }
 
   @Transactional
@@ -71,27 +67,22 @@ public class TravelogueService {
   @Transactional
   public TravelogueDetailRes getTravelogueDetail(Long travelogueId, boolean canAddViewCount,
       Long memberId) {
-    Long countLikes = travelogueRepository.countLikes(travelogueId);
-    boolean isLiked = travelogueRepository.isLiked(memberId, travelogueId);
-    boolean isBookmarked = bookmarkRepository.exists(memberId, travelogueId);
 
-    Travelogue travelogue = travelogueRepository.getTravelogueDetail(travelogueId)
-        .orElseThrow(() -> new TravelogueNotFoundException(ErrorCode.TRAVELOGUE_NOT_FOUND));
+    TravelogueSimpleDetail simpleDetail = getSimpleDetail(travelogueId, memberId);
+    TravelogueDetailRes travelogueDetailRes =
+        TravelogueDetailRes.toDto(simpleDetail, isWriter(simpleDetail.memberId(), memberId));
 
-    updateViewCount(travelogueId, canAddViewCount);
+    travelogueViewService.increase(simpleDetail.travelogue()
+            .getViews()
+            .getId(),
+        canAddViewCount);
 
-    Suggestion suggestion = new Suggestion(travelogue.getCountry().getName(), memberId);
-    suggestionRepository.save(suggestion);
-
-    boolean isWriter = isWriter(travelogue.getMember(), memberId);
-
-    return TravelogueDetailRes.toDto(travelogue, countLikes, isLiked, isBookmarked, isWriter);
+    return travelogueDetailRes;
   }
 
-  private void updateViewCount(Long travelogueId, boolean canAddViewCount) {
-    if (canAddViewCount) {
-      getTravelogue(travelogueId).addViewCount();
-    }
+  private TravelogueSimpleDetail getSimpleDetail(Long travelogueId, Long memberId) {
+    return travelogueRepository.getTravelogueDetail(travelogueId, memberId)
+        .orElseThrow(() -> new TravelogueNotFoundException(ErrorCode.TRAVELOGUE_NOT_FOUND));
   }
 
   public TravelogueCustomSlice<TravelogueSimpleRes> filtering(String keyword, Pageable pageable,
@@ -100,7 +91,8 @@ public class TravelogueService {
         travelogueRepository.filtering(keyword, pageable, searchFilter));
   }
 
-  private boolean isWriter(Member writer, Long requestMemberId) {
-    return Objects.equals(writer.getId(), requestMemberId);
+  private boolean isWriter(Long writerMemberId, Long requestMemberId) {
+    return Objects.equals(writerMemberId, requestMemberId);
   }
+
 }

--- a/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueViewService.java
+++ b/src/main/java/shop/zip/travel/domain/post/travelogue/service/TravelogueViewService.java
@@ -1,0 +1,22 @@
+package shop.zip.travel.domain.post.travelogue.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.zip.travel.domain.post.travelogue.repository.TravelogueViewRepository;
+
+@Service
+public class TravelogueViewService {
+
+  private final TravelogueViewRepository travelogueViewRepository;
+
+  public TravelogueViewService(TravelogueViewRepository travelogueViewRepository) {
+    this.travelogueViewRepository = travelogueViewRepository;
+  }
+
+  @Transactional
+  public void increase(Long id, boolean canAddViewCount) {
+    if (canAddViewCount) {
+      travelogueViewRepository.increaseCount(id);
+    }
+  }
+}

--- a/src/test/java/shop/zip/travel/domain/post/fake/FakeTravelogue.java
+++ b/src/test/java/shop/zip/travel/domain/post/fake/FakeTravelogue.java
@@ -14,7 +14,7 @@ public class FakeTravelogue extends Travelogue {
         travelogue.getCountry(),
         travelogue.getThumbnail(),
         travelogue.getCost(),
-        travelogue.getIsPublished(),
+        travelogue.isPublished(),
         travelogue.getSubTravelogues(),
         travelogue.getMember(),
         new Views(0L)

--- a/src/test/java/shop/zip/travel/domain/post/fake/FakeTravelogue.java
+++ b/src/test/java/shop/zip/travel/domain/post/fake/FakeTravelogue.java
@@ -1,27 +1,29 @@
 package shop.zip.travel.domain.post.fake;
 
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+import shop.zip.travel.domain.post.travelogue.entity.Views;
 
 public class FakeTravelogue extends Travelogue {
 
-	private final Long id;
+  private final Long id;
 
-	public FakeTravelogue(Long id, Travelogue travelogue) {
-		super(
-			travelogue.getPeriod(),
-			travelogue.getTitle(),
-			travelogue.getCountry(),
-			travelogue.getThumbnail(),
-			travelogue.getCost(),
-			travelogue.getIsPublished(),
-			travelogue.getSubTravelogues(),
-			travelogue.getMember()
-		);
-		this.id = id;
-	}
+  public FakeTravelogue(Long id, Travelogue travelogue) {
+    super(
+        travelogue.getPeriod(),
+        travelogue.getTitle(),
+        travelogue.getCountry(),
+        travelogue.getThumbnail(),
+        travelogue.getCost(),
+        travelogue.getIsPublished(),
+        travelogue.getSubTravelogues(),
+        travelogue.getMember(),
+        new Views(0L)
+    );
+    this.id = id;
+  }
 
-	@Override
-	public Long getId() {
-		return id;
-	}
+  @Override
+  public Long getId() {
+    return id;
+  }
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
@@ -138,7 +138,7 @@ public class DummyGenerator {
   public static SubTravelogue createSubTravelogueWithRegion(String region) {
     return new SubTravelogue(
         "일본 오사카 재밌음",
-        "오사카 갔는데 또 가고 싶음",
+        "또 가고 싶음",
         1,
         List.of(new Address(region)),
         Set.of(Transportation.BUS),
@@ -148,7 +148,7 @@ public class DummyGenerator {
 
   public static Address createAddress() {
     return new Address(
-        "일본 오사카 유니버셜 스튜디오"
+        "유니버셜"
     );
   }
 
@@ -269,7 +269,9 @@ public class DummyGenerator {
         member.getNickname(),
         0L,
         false,
-        false
+        false,
+        1L,
+        List.of(createSubTravelogue(2))
     );
   }
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/DummyGenerator.java
@@ -16,12 +16,14 @@ import shop.zip.travel.domain.post.travelogue.data.Cost;
 import shop.zip.travel.domain.post.travelogue.data.Period;
 import shop.zip.travel.domain.post.travelogue.dto.TempTravelogueSimple;
 import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimple;
+import shop.zip.travel.domain.post.travelogue.dto.TravelogueSimpleDetail;
 import shop.zip.travel.domain.post.travelogue.dto.req.CostCreateReq;
 import shop.zip.travel.domain.post.travelogue.dto.req.CountryCreateReq;
 import shop.zip.travel.domain.post.travelogue.dto.req.PeriodCreateReq;
 import shop.zip.travel.domain.post.travelogue.dto.req.TravelogueUpdateReq;
 import shop.zip.travel.domain.post.travelogue.dto.res.TravelogueSimpleRes;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+import shop.zip.travel.domain.post.travelogue.entity.Views;
 
 public class DummyGenerator {
 
@@ -36,7 +38,8 @@ public class DummyGenerator {
         createCost(),
         false,
         subTravelogues,
-        member
+        member,
+        new Views(0L)
     );
   }
 
@@ -53,7 +56,8 @@ public class DummyGenerator {
         createCost(),
         true,
         subTravelogues,
-        member
+        member,
+        new Views(0L)
     );
   }
 
@@ -87,7 +91,8 @@ public class DummyGenerator {
         createCost(),
         true,
         subTravelogues,
-        member
+        member,
+        new Views(0L)
     );
   }
 
@@ -103,7 +108,8 @@ public class DummyGenerator {
         createCost(),
         true,
         subTravelogues,
-        member
+        member,
+        new Views(0L)
     );
   }
 
@@ -253,5 +259,17 @@ public class DummyGenerator {
 
   public static TempTravelogueSimple createTempTravelogueSimple(Travelogue travelogue) {
     return new TempTravelogueSimple(travelogue, 256L);
+  }
+
+  public static TravelogueSimpleDetail createTravelogueSimpleDetail(Travelogue travelogue, Member member) {
+    return new TravelogueSimpleDetail(
+        travelogue,
+        member.getId(),
+        member.getProfileImageUrl(),
+        member.getNickname(),
+        0L,
+        false,
+        false
+    );
   }
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/data/TravelogueTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/data/TravelogueTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import shop.zip.travel.domain.post.travelogue.DummyGenerator;
 import shop.zip.travel.domain.post.travelogue.entity.Travelogue;
+import shop.zip.travel.domain.post.travelogue.entity.Views;
 
 class TravelogueTest {
 
@@ -25,7 +26,8 @@ class TravelogueTest {
 				DummyGenerator.createCost(),
 				isPublished,
 				List.of(DummyGenerator.createSubTravelogue(1)),
-				null
+				null,
+				new Views(0L)
 		)).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/entity/TravelogueTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/entity/TravelogueTest.java
@@ -56,7 +56,7 @@ class TravelogueTest {
     assertThat(travelogue.getThumbnail())
         .isEqualTo(travelogueUpdate.getThumbnail());
 
-    assertThat(travelogue.getIsPublished()).isFalse();
+    assertThat(travelogue.isPublished()).isFalse();
   }
 
   @Test

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepositoryTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/repository/TravelogueRepositoryTest.java
@@ -66,7 +66,7 @@ class TravelogueRepositoryTest {
 	@DisplayName("Travelogue의 모든 디테일한 정보를 불러올 수 있다.")
 	void test_get_all_data_on_travelogue() {
 		Long travelogueId = travelogue.getId();
-		Travelogue expected = travelogueRepository.getTravelogueDetail(travelogueId).get();
+		Travelogue expected = travelogueRepository.findById(travelogueId).get();
 
 		assertThat(travelogue).usingRecursiveComparison()
 				.isEqualTo(expected);

--- a/src/test/java/shop/zip/travel/domain/post/travelogue/service/TraveloguePublishServiceTest.java
+++ b/src/test/java/shop/zip/travel/domain/post/travelogue/service/TraveloguePublishServiceTest.java
@@ -69,6 +69,6 @@ class TraveloguePublishServiceTest {
         get();
 
     boolean actualPublishStatus = true;
-    assertThat(actualPublishStatus).isEqualTo(findTravelogue.getIsPublished());
+    assertThat(actualPublishStatus).isEqualTo(findTravelogue.isPublished());
   }
 }

--- a/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
+++ b/src/test/java/shop/zip/travel/presentation/travelogue/TravelogueControllerTest.java
@@ -283,9 +283,9 @@ class TravelogueControllerTest {
             )));
   }
 
-  @DisplayName("유저는 나라이름, 게시글 제목, 게시글 내용, 장소로 게시물을 검색할 수 있다")
+  @DisplayName("유저는 나라이름, 게시글 제목, 장소로 게시물을 검색할 수 있다")
   @ParameterizedTest
-  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본", "또 가고 싶음", "유니버셜"})
+  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본", "유니버셜"})
   void test_search(String keyword) throws Exception {
 
     travelogue1.changePublishStatus();
@@ -338,7 +338,7 @@ class TravelogueControllerTest {
 
   @DisplayName("유저는 기간으로 필터링하여 검색 할 수 있다")
   @ParameterizedTest
-  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본", "또 가고 싶음"})
+  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본"})
   void test_search_with_filter_period(String keyword) throws Exception {
 
     travelogue1.changePublishStatus();
@@ -398,7 +398,7 @@ class TravelogueControllerTest {
 
   @DisplayName("유저는 가격범위로 필터링하여 검색 할 수 있다")
   @ParameterizedTest
-  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본", "또 가고 싶음"})
+  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본"})
   void test_search_with_filter_cost(String keyword) throws Exception {
 
     travelogue1.changePublishStatus();
@@ -458,7 +458,7 @@ class TravelogueControllerTest {
 
   @DisplayName("유저는 가격과 기간으로 필터링 검색을 할 수 있다")
   @ParameterizedTest
-  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본", "또 가고 싶음"})
+  @ValueSource(strings = {"일본 오사카 다녀왔어요.", "일본"})
   void test_search_with_filter(String keyword) throws Exception {
 
     travelogue1.changePublishStatus();


### PR DESCRIPTION
## 개발 내용 한줄 요약
- 비관적락으로 동시성을 잡았던 조회수 increase로직을 bulk update쿼리로 변경하였습니다. 

## 개발 세부 사항
- 조회시 나가는 쿼리가 10개인것을 확인하였고 총 5개로 줄였습니다(조회수 Update쿼리 포함).
- 비관적락에서 bulk update로 변경하였습니다 

## 코드리뷰 룰
R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
C(Comment): 웬만하면 고려해주시면 좋겠습니다.
A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
